### PR TITLE
Added Tuner parameter to tunerScanProgress()

### DIFF
--- a/src/org/omri/tuner/TunerListener.java
+++ b/src/org/omri/tuner/TunerListener.java
@@ -17,7 +17,7 @@ import org.omri.radioservice.RadioService;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * The {@link Tuner} listener interface
  * @author Fabian Sattler, IRT GmbH
  */
@@ -28,34 +28,34 @@ public interface TunerListener extends RadioListener {
 	 * @param newStatus the new {@link TunerStatus}
 	 */
 	public void tunerStatusChanged(Tuner tuner, TunerStatus newStatus);
-	
+
 	/**
 	 * Tuner scan progress indicator
 	 * @param percentScanned the percentage finished so far
 	 */
-	public void tunerScanProgress(int percentScanned);
-	
+	public void tunerScanProgress(Tuner tuner, int percentScanned);
+
 	/**
 	 * A {@link RadioService} started
 	 * @param startedRadioService the {@link RadioService} which has started
 	 */
 	public void radioServiceStarted(Tuner tuner, RadioService startedRadioService);
-	
+
 	/**
 	 * A {@link RadioService} stopped
 	 * @param stoppedRadioService the {@link RadioService} which has stopped
 	 */
 	public void radioServiceStopped(Tuner tuner, RadioService stoppedRadioService);
-	
+
 	/**
 	 * Updates on RF reception statistics
 	 * @param rfLock RF tuner frontend gained lock
 	 * @param rssi the Received Signal Strength Indicator (in dbµV ???)
 	 */
 	public void tunerReceptionStatistics(Tuner tuner, boolean rfLock, int rssi);
-	
+
 	/**
-	 * Implementation and TunerType dependent raw data (e.g. in case of a DAB Tuner raw Fast Information Blocks) 
+	 * Implementation and TunerType dependent raw data (e.g. in case of a DAB Tuner raw Fast Information Blocks)
 	 * @param tuner the Tuner from which the raw data was received
 	 * @param data the raw data
 	 */


### PR DESCRIPTION
For consistency with the other methods in `TunerListener`, this PR adds a `Tuner` parameter to `tunerScanProgress`.
